### PR TITLE
Set PHP 7.1 as the minimal PHP version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         }
     ],
     "require": {
+        "php": ">=7.1",
         "league/oauth2-server": "^6.1",
         "doctrine/collections": "^1.5",
         "ramsey/uuid": "^3.7",


### PR DESCRIPTION
Useful for IDEs and editors which parse the `composer.json` file for settings.